### PR TITLE
Replace hyphens with underscores

### DIFF
--- a/plugin/caddyfile/fromlabels.go
+++ b/plugin/caddyfile/fromlabels.go
@@ -5,11 +5,12 @@ import (
 	"math"
 	"regexp"
 	"strconv"
+	"strings"
 	"text/template"
 )
 
 var whitespaceRegex = regexp.MustCompile("\\s+")
-var labelParserRegex = regexp.MustCompile(`^(?:(.+)\.)?(?:(\d+)_)?([^.]+?)(?:_(\d+))?$`)
+var labelParserRegex = regexp.MustCompile(`^(?:(.+)\.)?(?:(\d+)[_-])?([^.]+?)(?:[_-](\d+))?$`)
 
 // FromLabels converts key value labels into a caddyfile
 func FromLabels(labels map[string]string, templateData interface{}, templateFuncs template.FuncMap) (*Container, error) {
@@ -38,6 +39,9 @@ func getOrCreateBlock(container *Container, path string, blocksByPath map[string
 	}
 
 	parentPath, order, name := parsePath(path)
+
+	// support reverse-proxy and reverse_proxy for strict label implemntations
+	name = strings.Replace(name, "-", "_", -1)
 
 	block := CreateBlock()
 	block.Order = order

--- a/plugin/generator/testdata/labels/hyphens.txt
+++ b/plugin/generator/testdata/labels/hyphens.txt
@@ -1,0 +1,13 @@
+caddy                       = service.testdomain.com
+caddy.route                 = /path/*
+caddy.route.0-uri           = strip_prefix /path
+caddy.route.1_rewrite       = * /api{path}
+caddy.route.2-reverse-proxy = {{upstreams https 5000}}
+----------
+service.testdomain.com {
+	route /path/* {
+		uri strip_prefix /path
+		rewrite * /api{path}
+		reverse_proxy https://target:5000
+	}
+}


### PR DESCRIPTION
This supports overly restrictive docker compose implementations

https://github.com/lucaslorentz/caddy-docker-proxy/issues/362